### PR TITLE
Fixes/QoL stuff

### DIFF
--- a/rel/include/ttyd/icondrv.h
+++ b/rel/include/ttyd/icondrv.h
@@ -592,6 +592,6 @@ namespace ttyd::icondrv
     extern "C"
     {
         void iconNumberDispGx(gc::mtx34 *matrix, int32_t number, int32_t is_small, uint32_t *color);
-        void iconDispGx(double unk0, gc::vec3 *pos, int16_t unk2, uint16_t icon);
+        void iconDispGx(float scale, gc::vec3 *pos, int16_t unk2, uint16_t icon);
     }
 } // namespace ttyd::icondrv

--- a/rel/include/ttyd/win_main.h
+++ b/rel/include/ttyd/win_main.h
@@ -28,10 +28,10 @@ namespace ttyd::win_main
         void winTexSet(uint32_t unk, gc::vec3 *pos, gc::vec3 *scale, uint32_t *color);
         void winTexInit(void *tpl_file_data);
         // winFontSetLabel
-        void winFontSetEdgeWidth(gc::vec3 *pos, gc::vec3 *scale, uint32_t *color, double width, const char *str);
+        void winFontSetEdgeWidth(gc::vec3 *pos, gc::vec3 *scale, uint32_t *color, float width, const char *str);
         void winFontSetEdge(gc::vec3 *pos, gc::vec3 *scale, uint32_t *color, const char *str);
         void winFontSetR(gc::vec3 *pos, gc::vec3 *scale, uint32_t *color, const char *str, ...);
-        void winFontSetWidth(gc::vec3 *pos, gc::vec3 *scale, uint32_t *color, double length, const char *str);
+        void winFontSetWidth(gc::vec3 *pos, gc::vec3 *scale, uint32_t *color, float width, const char *str);
         void winFontSet(gc::vec3 *pos, gc::vec3 *scale, uint32_t *color, const char *str, ...);
         void winFontInit();
         // winGhostDiaryChk

--- a/rel/include/ttyd/win_root.h
+++ b/rel/include/ttyd/win_root.h
@@ -305,7 +305,7 @@ namespace ttyd::win_root
         void winZClear();
         void winKageGX(float x, float y, float z, float scale, WinPauseMenu *menu, uint32_t *color);
         uint32_t winSortWait(WinPauseMenu *menu);
-        void winSortEntry(double x, double y, WinPauseMenu *menu, int sortType);
+        void winSortEntry(float x, float y, WinPauseMenu *menu, int sortType);
         // winSortGX
         // winSortMain
         // sort_8_2_func
@@ -360,7 +360,7 @@ namespace ttyd::win_root
         void winMsgEntry(WinPauseMenu *menu, int32_t item_id, const char *msg, const char *name);
         // winMsgDisp
         // winMsgMain
-        void winBgGX(double x, double y, WinPauseMenu *menu, int32_t type);
+        void winBgGX(float x, float y, WinPauseMenu *menu, int32_t type);
         // winBgMain
         void winRootDisp(ttyd::dispdrv::CameraId camera, ttyd::win_root::WinPauseMenu *menu);
         // winRootMain

--- a/rel/source/OWR.cpp
+++ b/rel/source/OWR.cpp
@@ -957,9 +957,8 @@ namespace mod::owr
         {
             case 10:
             {
-                if ((menu->itemSubmenuId == 1) &&
+                if ((menu->buttonsPressed & gc::pad::PadInput::PAD_A) && (menu->itemSubmenuId == 1) &&
                     (menu->keyItemIds[menu->itemsCursorIdx[1]] == ItemId::INVALID_ITEM_PAPER_0054) &&
-                    (menu->buttonsPressed & gc::pad::PadInput::PAD_A) &&
                     (marioGetPtr()->characterId == MarioCharacters::kMario))
                 {
                     ttyd::evtmgr::evtEntry(const_cast<int32_t *>(confirm_pipe_evt), 0, 0);

--- a/rel/source/OWR.cpp
+++ b/rel/source/OWR.cpp
@@ -570,7 +570,7 @@ namespace mod::owr
         // Only re-add it if it was previously in the inventory, as it won't be when initially starting a new file
         if (pouchRemoveItem(ItemId::INVALID_ITEM_PAPER_0054))
         {
-            g_pouchGetItem_trampoline(ItemId::INVALID_ITEM_PAPER_0054);
+            pouchGetItem(ItemId::INVALID_ITEM_PAPER_0054);
         }
     }
 

--- a/rel/source/OWR.cpp
+++ b/rel/source/OWR.cpp
@@ -603,11 +603,6 @@ namespace mod::owr
                 ttyd::mario_party::partyJoin(PartyMembers::kVivian);
                 return 1;
             }
-            case ItemId::INVALID_ITEM_PAPER_0054:
-            {
-                // Give the return pipe without running pouchReAddReturnPipe
-                return g_pouchGetItem_trampoline(item);
-            }
             case ItemId::INVALID_ITEM_006F:
             {
                 ttyd::mario_party::partyJoin(PartyMembers::kBobbery);
@@ -621,6 +616,11 @@ namespace mod::owr
             case ItemId::INVALID_ITEM_0071:
             {
                 return 1;
+            }
+            case ItemId::INVALID_ITEM_PAPER_0054:
+            {
+                // Give the return pipe without running pouchReAddReturnPipe
+                return g_pouchGetItem_trampoline(item);
             }
             case ItemId::INVALID_ITEM_PAPER_0053:
             {

--- a/rel/source/OWR.cpp
+++ b/rel/source/OWR.cpp
@@ -914,9 +914,7 @@ namespace mod::owr
     {
         (void)isFirstCall;
 
-        int ch5 = ttyd::swdrv::swByteGet(1717);
-        int ch6 = ttyd::swdrv::swByteGet(1706);
-
+        const int ch5 = ttyd::swdrv::swByteGet(1717);
         if (10 <= ch5 && ch5 <= 18)
         {
             if (!strcmp(_next_area, "muj"))
@@ -924,7 +922,9 @@ namespace mod::owr
                 ttyd::evtmgr_cmd::evtSetValue(evt, evt->evtArguments[0], 1);
             }
         }
-        else if (42 <= ch6 && ch6 <= 43)
+
+        const int ch6 = ttyd::swdrv::swByteGet(1706);
+        if (42 <= ch6 && ch6 <= 43)
         {
             ttyd::evtmgr_cmd::evtSetValue(evt, evt->evtArguments[0], 1);
         }

--- a/rel/source/OWR.cpp
+++ b/rel/source/OWR.cpp
@@ -901,9 +901,6 @@ namespace mod::owr
             uint32_t namePtr = 0x802c0298;
             const char *mapName = reinterpret_cast<char *>(namePtr);
             ttyd::seqdrv::seqSetSeq(ttyd::seqdrv::SeqIndex::kMapChange, mapName, 0);
-
-            // Prevent giving back control to the player
-            ttyd::evtmgr_cmd::evtSetValue(evt, evt->evtArguments[0], 100);
         }
 
         return 2;
@@ -946,7 +943,7 @@ namespace mod::owr
         USER_FUNC(evt_msg_select, 1, PTR("<select 0 1 0 40>\nYes\nNo"))
         USER_FUNC(evt_msg_continue)
         USER_FUNC(handlePipeConfirmResponse, LW(0))
-        IF_NOT_EQUAL(LW(0), 100)
+        IF_NOT_EQUAL(LW(0), 0)
             USER_FUNC(evt_mario_key_onoff, 1)
         END_IF()
         RETURN()

--- a/rel/source/OWR.cpp
+++ b/rel/source/OWR.cpp
@@ -868,12 +868,15 @@ namespace mod::owr
     KEEP_FUNC void SetMaxSP(int star)
     {
         PouchData *pouchData = pouchGetPtr();
-        int16_t maxSP = pouchData->max_sp;
-        int16_t newMaxSP = star * 100;
+        const int32_t maxSP = pouchData->max_sp;
+
         g_pouchGetStarstone_trampoline(star);
+
+        const int32_t newMaxSP = star * 100;
         if (newMaxSP < maxSP)
-            pouchData->max_sp = maxSP;
-        return;
+        {
+            pouchData->max_sp = static_cast<int16_t>(maxSP);
+        }
     }
 
     EVT_DECLARE_USER_FUNC(handlePipeConfirmResponse, 1)

--- a/rel/subrels/init/source/OWR.cpp
+++ b/rel/subrels/init/source/OWR.cpp
@@ -190,8 +190,6 @@ EVT_BEGIN(main_evt_sub_starstone_hook)
 EVT_PATCH_END()
 // clang-format on
 
-
-
 namespace mod::owr
 {
     void ApplyMainAssemblyPatches()


### PR DESCRIPTION
When an important item is given, the return pipe is removed and re-added to the important items, effectively sorting it to the top of the inventory.

Prevent giving back control to the player upon warping via the return pipe.

Prevent setting starting stats if AP is not enabled.

Changes instances of `double` to `float`.

Several other small optimizations.