### PR TITLE
Raise/Lower system level in confirm_pipe_evt

### DIFF
--- a/rel/include/ttyd.us.lst
+++ b/rel/include/ttyd.us.lst
@@ -3314,6 +3314,14 @@ D,1,00004de8:jin_evt_kagemario_init
 // 8041de08:marioAttackEvent_Genki0
 // 8041de24:marioAttackEvent_Genki1
 
+// evt_lecture.o
+// 80257574:lect_juyoitem_rel_get
+// 802575A4:lect_juyoitem_rel_set
+// 802575D4:lect_cam_load
+// 802577B4:lect_cam_save
+// 802578FC:lect_test_systemlevel
+80257920:lect_set_systemlevel
+
 // evt_memcard.o
 // .text
 // 8025c0b8:memcard_write

--- a/rel/include/ttyd/evt_lecture.h
+++ b/rel/include/ttyd/evt_lecture.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "ttyd/evtmgr.h"
+
+#include <cstdint>
+
+namespace ttyd::evt_lecture
+{
+    extern "C"
+    {
+        // lect_juyoitem_rel_get
+        // lect_juyoitem_rel_set
+        // lect_cam_load
+        // lect_cam_save
+        // lect_test_systemlevel
+
+        // lect_set_systemlevel(int32_t level)
+        EVT_DECLARE_USER_FUNC(lect_set_systemlevel, 1);
+    }
+} // namespace ttyd::evt_lecture

--- a/rel/source/OWR.cpp
+++ b/rel/source/OWR.cpp
@@ -951,6 +951,7 @@ namespace mod::owr
         IF_EQUAL(LW(0), 1)
             USER_FUNC(evt_msg_print, 1, PTR("<system>\n<p>\nThe Warp Pipe is currently\nunavailable.<k>"), 0, 0)
             USER_FUNC(evt_mario_key_onoff, 1)
+            USER_FUNC(lect_set_systemlevel, 0)
             RETURN()
         END_IF()
         USER_FUNC(evt_msg_print, 1, PTR("<system>\n<p>\nWarp home now?\n<o>"), 0, 0)

--- a/rel/source/OWR.cpp
+++ b/rel/source/OWR.cpp
@@ -17,6 +17,7 @@
 #include <ttyd/evt_pouch.h>
 #include <ttyd/evt_snd.h>
 #include <ttyd/evt_window.h>
+#include <ttyd/evt_lecture.h>
 #include <ttyd/evtmgr.h>
 #include <ttyd/evtmgr_cmd.h>
 #include <ttyd/icondrv.h>
@@ -55,6 +56,7 @@ using namespace ttyd::statuswindow;
 using namespace ttyd::evt_mario;
 using namespace ttyd::evt_msg;
 using namespace ttyd::evt_pouch;
+using namespace ttyd::evt_lecture;
 using namespace ttyd::seqdrv;
 
 const uint16_t GSWF_ARR[] = {
@@ -207,12 +209,14 @@ namespace mod::owr
 
     bool checkIfInGame()
     {
-        if (seqGetNextSeq() != SeqIndex::kGame && seqGetNextSeq() != SeqIndex::kBattle)
+        const ttyd::seqdrv::SeqIndex nextSeq = seqGetNextSeq();
+        if ((nextSeq != SeqIndex::kGame) && (nextSeq != SeqIndex::kBattle))
         {
             return false;
         }
 
-        if (seqGetSeq() != SeqIndex::kGame && seqGetSeq() != SeqIndex::kBattle)
+        const ttyd::seqdrv::SeqIndex currentSeq = seqGetSeq();
+        if ((currentSeq != SeqIndex::kGame) && (currentSeq != SeqIndex::kBattle))
         {
             return false;
         }
@@ -941,6 +945,7 @@ namespace mod::owr
 
     // clang-format off
     EVT_BEGIN(confirm_pipe_evt)
+        USER_FUNC(lect_set_systemlevel, 1)
         USER_FUNC(evt_mario_key_onoff, 0)
         USER_FUNC(checkValidPipeSequence, LW(0))
         IF_EQUAL(LW(0), 1)
@@ -957,6 +962,7 @@ namespace mod::owr
         ELSE()
             USER_FUNC(evt_mario_key_onoff, 1)
         END_IF()
+        USER_FUNC(lect_set_systemlevel, 0)
         RETURN()
     EVT_END()
     // clang-format on
@@ -972,7 +978,9 @@ namespace mod::owr
                     (menu->keyItemIds[menu->itemsCursorIdx[1]] == ItemId::INVALID_ITEM_PAPER_0054) &&
                     (marioGetPtr()->characterId == MarioCharacters::kMario))
                 {
-                    ttyd::evtmgr::evtEntry(const_cast<int32_t *>(confirm_pipe_evt), 0, 0);
+                    // Params taken from `evtEntryType` call in `mobjRunEvent` for running `mobj_save_blk_sysevt`, as using
+                    // `evtEntry` causes message selection boxes to not show up when system level is raised
+                    ttyd::evtmgr::evtEntryType(const_cast<int32_t *>(confirm_pipe_evt), 30, 0, 26);
                     return -2;
                 }
                 break;

--- a/rel/source/OWR.cpp
+++ b/rel/source/OWR.cpp
@@ -980,7 +980,8 @@ namespace mod::owr
                     (marioGetPtr()->characterId == MarioCharacters::kMario))
                 {
                     // Params taken from `evtEntryType` call in `mobjRunEvent` for running `mobj_save_blk_sysevt`, as using
-                    // `evtEntry` causes message selection boxes to not show up when system level is raised
+                    // `evtEntry` causes message selection boxes to not show up when the system level is raised, and certain
+                    // `types` cause the script to only run once the pause menu is fully closed
                     ttyd::evtmgr::evtEntryType(const_cast<int32_t *>(confirm_pipe_evt), 30, 0, 26);
                     return -2;
                 }


### PR DESCRIPTION
This is mainly to have time frozen when the dialogue window is open, so that the player cannot abuse it by having the window open to make enemies pass by and whatnot.

Also made small optimizations in checkIfInGame.