### PR TITLE
Fast travel

### DIFF
--- a/rel/include/AP/rel_patch_definitions.h
+++ b/rel/include/AP/rel_patch_definitions.h
@@ -7,12 +7,16 @@ extern "C"
     EVT_DECLARE_USER_FUNC(tou_evt_tou_get_ranking, 1)
     EVT_DECLARE_USER_FUNC(muj_koburon_get_encount_info, 1)
 
+    void bMapGXArrPtrInit();
+    void bMapGXArrPtrInitReturn();
     void bMapGXArrInject();
     void bMapGXArrInjectReturn();
     void bMapGXArrIncrement();
     void bMapGXArrIncrementReturn();
     void bMapGXChSplit();
     void bMapGXChSplitReturn();
+    void bWinLogArrPtrInit();
+    void bWinLogArrPtrInitReturn();
     void bWinLogArrInject();
     void bWinLogArrInjectReturn();
     void bWinLogArrIncrement();

--- a/rel/include/OWR.h
+++ b/rel/include/OWR.h
@@ -46,6 +46,7 @@ namespace mod::owr
     void DisplayStarPowerOrbs(float x, float y, int32_t star_power);
     void SetMaxSP(int32_t star);
     int32_t WinItemMainHook(ttyd::win_root::WinPauseMenu *menu);
+    int32_t WinLogMainHook(ttyd::win_root::WinPauseMenu *menu);
 
     extern bool (*g_OSLink_trampoline)(OSModuleInfo *, void *);
     extern void (*g_seqSetSeq_trampoline)(SeqIndex seq, const char *map, const char *bero);
@@ -57,6 +58,7 @@ namespace mod::owr
     extern void (*g_statusWinDisp_trampoline)(void);
     extern void (*g_pouchGetStarstone_trampoline)(int32_t);
     extern int32_t (*g_winItemMain_trampoline)(ttyd::win_root::WinPauseMenu *menu);
+    extern int32_t (*g_winLogMain_trampoline)(ttyd::win_root::WinPauseMenu *menu);
 
     extern const char *goombellaName;
     extern const char *goombellaDescription;

--- a/rel/include/StateManager.h
+++ b/rel/include/StateManager.h
@@ -21,6 +21,7 @@ namespace mod::owr
         uint8_t startingFP;
         uint8_t startingBP;
         uint8_t runFill;
+        uint8_t fastTravel;
         uint8_t requiredStars[7];
         uint8_t tattlesanity;
     };

--- a/rel/include/ttyd.us.lst
+++ b/rel/include/ttyd.us.lst
@@ -3644,6 +3644,10 @@ D,1,00004de8:jin_evt_kagemario_init
 // .data
 803108a8:itemDataTable
 
+// win_log.o
+// .data
+80377918:mapMarkers
+
 // itemdrv.o
 // 800AA4FC:itemPickUp
 // 800AA530:itemStatus

--- a/rel/include/ttyd/win_log.h
+++ b/rel/include/ttyd/win_log.h
@@ -27,6 +27,8 @@ namespace ttyd::win_log
         static_assert(sizeof(MapMarker) == 0xC);
 
         extern MapMarker mapMarkers[0x5D];
+
+        int32_t main_winLogMain(ttyd::win_root::WinPauseMenu *menu);
     }
 
 } // namespace ttyd::win_log

--- a/rel/include/ttyd/win_log.h
+++ b/rel/include/ttyd/win_log.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <ttyd/dispdrv.h>
+
+#include <cstdint>
+
+namespace ttyd::win_root
+{
+    struct WinPauseMenu;
+} // namespace ttyd::win_root
+
+namespace ttyd::win_log
+{
+
+    extern "C"
+    {
+        struct MapMarker
+        {
+            // 0,0 is at the middle of the map
+            int16_t x_pos;
+            int16_t y_pos;
+            uint8_t isLocation; // trail marker if 0
+            uint8_t unk_0x05;   // if required_sequence isn't met, used to conditionally show anyway. can take the values [0-4]
+            uint16_t required_sequence;
+            const char *map_prefix; // the three letter string E.g. "gor"
+        };
+        static_assert(sizeof(MapMarker) == 0xC);
+
+        extern MapMarker mapMarkers[0x5D];
+    }
+
+} // namespace ttyd::win_log

--- a/rel/source/OWR.cpp
+++ b/rel/source/OWR.cpp
@@ -1108,6 +1108,8 @@ namespace mod::owr
         {
             case 10: // map open
             {
+                if (!gState->apSettings->fastTravel)
+                    break;
                 if (menu->mapCursorIdx < 0) // no location selected
                     break;
                 if (menu->buttonsPressed & gc::pad::PadInput::PAD_A && marioGetPtr()->characterId == MarioCharacters::kMario)

--- a/rel/source/OWR.cpp
+++ b/rel/source/OWR.cpp
@@ -3,6 +3,7 @@
 #include <AP/rel_patch_definitions.h>
 #include <cstdint>
 #include <cstring>
+#include <cstdio>
 #include <gc/OSModule.h>
 #include <gc/pad.h>
 #include <mod.h>
@@ -33,6 +34,7 @@
 #include <ttyd/statuswindow.h>
 #include <ttyd/string.h>
 #include <ttyd/swdrv.h>
+#include <ttyd/win_log.h>
 #include <ttyd/win_main.h>
 #include <ttyd/win_root.h>
 
@@ -132,6 +134,7 @@ namespace mod::owr
     KEEP_VAR void (*g_statusWinDisp_trampoline)(void) = nullptr;
     KEEP_VAR void (*g_pouchGetStarstone_trampoline)(int32_t) = nullptr;
     KEEP_VAR int32_t (*g_winItemMain_trampoline)(ttyd::win_root::WinPauseMenu *menu) = nullptr;
+    KEEP_VAR int32_t (*g_winLogMain_trampoline)(ttyd::win_root::WinPauseMenu *menu) = nullptr;
 
     void OWR::SequenceInit()
     {
@@ -886,8 +889,65 @@ namespace mod::owr
         }
     }
 
-    EVT_DECLARE_USER_FUNC(handlePipeConfirmResponse, 1)
-    EVT_DEFINE_USER_FUNC(handlePipeConfirmResponse)
+    struct FastTravelPair
+    {
+        const char *map_name;
+        const char *bero;
+    };
+    const FastTravelPair getFastTravelPair()
+    {
+        const char *map_prefix = ttyd::win_log::mapMarkers[ttyd::win_main::main_winGetPtr()->mapCursorIdx].map_prefix;
+        if (strcmp(map_prefix, "tik") == 0)
+            return {"tik_01", "dokan_2"};
+        if (strcmp(map_prefix, "hei") == 0)
+            return {"hei_00", "dokan_2"};
+        if (strcmp(map_prefix, "nok") == 0)
+            return {"nok_00", "w_bero"};
+        if (strcmp(map_prefix, "gon") == 0)
+            return {"gon_00", "w_bero"};
+        if (strcmp(map_prefix, "win") == 0)
+            return {"win_06", "dokan1"}; // not a typo
+        if (strcmp(map_prefix, "mri") == 0)
+            return {"mri_00", "w_bero"};
+        if (strcmp(map_prefix, "hou") == 0)
+            return {"win_04", "w_bero"};
+        if (strcmp(map_prefix, "tou") == 0)
+            return {"tou_01", nullptr}; // triggers the blimp entrance by default
+        if (strcmp(map_prefix, "usu") == 0)
+            return {"usu_00", "dokan_1"};
+        if (strcmp(map_prefix, "gra") == 0)
+            return {"gra_00", "w_bero"};
+        if (strcmp(map_prefix, "jin") == 0)
+            return {"gra_06", "sw_bero"};
+        if (strcmp(map_prefix, "muj") == 0)
+            return {"muj_00", "e_bero"};
+        if (strcmp(map_prefix, "dou") == 0)
+            return {"dou_00", "w_bero"};
+        if (strcmp(map_prefix, "eki") == 0)
+            return {"hom_00", "n_bero_1"};
+        if (strcmp(map_prefix, "pik") == 0)
+            return {"pik_00", "n_bero"};
+        if (strcmp(map_prefix, "sin") == 0)
+            return {"pik_02", "s_bero"};
+        if (strcmp(map_prefix, "bom") == 0)
+            return {"bom_02", "w_bero"};
+        if (strcmp(map_prefix, "moo") == 0)
+            return {"moo_00", nullptr}; // first time landing on the moon also uses null
+        if (strcmp(map_prefix, "aji") == 0)
+            return {"aji_00", "w_bero"};
+        if (strcmp(map_prefix, "las") == 0)
+            return {"las_00", "w_bero"};
+        return {"gor_01", "s_bero"};
+    }
+
+    enum class WarpType : uint8_t
+    {
+        WARP_PIPE,
+        FAST_TRAVEL,
+    };
+
+    EVT_DECLARE_USER_FUNC(handleWarpConfirmResponse, 2)
+    EVT_DEFINE_USER_FUNC(handleWarpConfirmResponse)
     {
         (void)isFirstCall;
 
@@ -910,14 +970,24 @@ namespace mod::owr
 
             uint32_t namePtr = 0x802c0298;
             const char *mapName = reinterpret_cast<char *>(namePtr);
-            ttyd::seqdrv::seqSetSeq(ttyd::seqdrv::SeqIndex::kMapChange, mapName, 0);
+            const char *bero = nullptr;
+
+            WarpType warpType = static_cast<WarpType>(ttyd::evtmgr_cmd::evtGetValue(evt, evt->evtArguments[1]));
+            if (warpType == WarpType::FAST_TRAVEL)
+            {
+                const FastTravelPair fastTravelPair = getFastTravelPair();
+                mapName = fastTravelPair.map_name;
+                bero = fastTravelPair.bero;
+            }
+
+            ttyd::seqdrv::seqSetSeq(ttyd::seqdrv::SeqIndex::kMapChange, mapName, bero);
         }
 
         return 2;
     }
 
-    EVT_DECLARE_USER_FUNC(checkValidPipeSequence, 1)
-    EVT_DEFINE_USER_FUNC(checkValidPipeSequence)
+    EVT_DECLARE_USER_FUNC(checkValidWarpSequence, 1)
+    EVT_DEFINE_USER_FUNC(checkValidWarpSequence)
     {
         (void)isFirstCall;
 
@@ -939,26 +1009,71 @@ namespace mod::owr
         return 2;
     }
 
+    EVT_DECLARE_USER_FUNC(getWarpUnavailableText, 2)
+    EVT_DEFINE_USER_FUNC(getWarpUnavailableText)
+    {
+        (void)isFirstCall;
+
+        const char *text = "<system>\n<p>\nThe Warp Pipe is currently\nunavailable.<k>";
+
+        WarpType warpType = static_cast<WarpType>(ttyd::evtmgr_cmd::evtGetValue(evt, evt->evtArguments[0]));
+        if (warpType == WarpType::FAST_TRAVEL)
+            text = "<system>\n<p>\nFast travel is currently\nunavailable.<k>";
+
+        ttyd::evtmgr_cmd::evtSetValue(evt, evt->evtArguments[1], reinterpret_cast<uint32_t>(text));
+
+        return 2;
+    }
+
+    // declared here so memory leaks aren't an issue
+    char *warp_confirm_text_buffer = new char[64]; // should be large enough
+    EVT_DECLARE_USER_FUNC(getWarpConfirmText, 2)
+    EVT_DEFINE_USER_FUNC(getWarpConfirmText)
+    {
+        (void)isFirstCall;
+
+        WarpType warpType = static_cast<WarpType>(ttyd::evtmgr_cmd::evtGetValue(evt, evt->evtArguments[0]));
+        if (warpType == WarpType::FAST_TRAVEL)
+        {
+            // memory location points to key used to find the title of the location on the journal map
+            const char *location_name = ttyd::msgdrv::msgSearch(reinterpret_cast<char *>(0x803e61b8));
+            sprintf(warp_confirm_text_buffer, "<system>\n<p>\nFast travel to\n%s?\n<o>", location_name);
+        }
+        else
+        {
+            sprintf(warp_confirm_text_buffer, "<system>\n<p>\nWarp home now?\n<o>");
+        }
+
+        ttyd::evtmgr_cmd::evtSetValue(evt, evt->evtArguments[1], reinterpret_cast<uint32_t>(warp_confirm_text_buffer));
+
+        return 2;
+    }
+
     // clang-format off
-    EVT_BEGIN(confirm_pipe_evt)
-        USER_FUNC(evt_mario_key_onoff, 0)
-        USER_FUNC(checkValidPipeSequence, LW(0))
-        IF_EQUAL(LW(0), 1)
-            USER_FUNC(evt_msg_print, 1, PTR("<system>\n<p>\nThe Warp Pipe is currently\nunavailable.<k>"), 0, 0)
-            USER_FUNC(evt_mario_key_onoff, 1)
-            RETURN()
-        END_IF()
-        USER_FUNC(evt_msg_print, 1, PTR("<system>\n<p>\nWarp home now?\n<o>"), 0, 0)
-        USER_FUNC(evt_msg_select, 1, PTR("<select 0 1 0 40>\nYes\nNo"))
-        USER_FUNC(evt_msg_continue)
-        USER_FUNC(handlePipeConfirmResponse, LW(0))
-        IF_EQUAL(LW(0), 0)
-            USER_FUNC(evt_mario_normalize)
-        ELSE()
-            USER_FUNC(evt_mario_key_onoff, 1)
-        END_IF()
-        RETURN()
+    #define WARP_EVT(name, type) EVT_BEGIN(name) \
+        USER_FUNC(evt_mario_key_onoff, 0) \
+        USER_FUNC(checkValidWarpSequence, LW(0)) \
+        IF_EQUAL(LW(0), 1) \
+            USER_FUNC(getWarpUnavailableText, type, LW(0)) \
+            USER_FUNC(evt_msg_print, 1, LW(0), 0, 0) \
+            USER_FUNC(evt_mario_key_onoff, 1) \
+            RETURN() \
+        END_IF() \
+        USER_FUNC(getWarpConfirmText, type, LW(0)) \
+        USER_FUNC(evt_msg_print, 1, LW(0), 0, 0) \
+        USER_FUNC(evt_msg_select, 1, PTR("<select 0 1 0 40>\nYes\nNo")) \
+        USER_FUNC(evt_msg_continue) \
+        USER_FUNC(handleWarpConfirmResponse, LW(0), type) \
+        IF_EQUAL(LW(0), 0) \
+            USER_FUNC(evt_mario_normalize) \
+        ELSE() \
+            USER_FUNC(evt_mario_key_onoff, 1) \
+        END_IF() \
+        RETURN() \
     EVT_END()
+
+    WARP_EVT(confirm_pipe_evt, static_cast<uint8_t>(WarpType::WARP_PIPE))
+    WARP_EVT(confirm_travel_evt, static_cast<uint8_t>(WarpType::FAST_TRAVEL))
     // clang-format on
 
     // Hook item menu update function to handle interactions with added key items.
@@ -984,6 +1099,31 @@ namespace mod::owr
         }
 
         return g_winItemMain_trampoline(menu);
+    }
+
+    // Hook journal menu to fast travel from the map
+    KEEP_FUNC int32_t WinLogMainHook(ttyd::win_root::WinPauseMenu *menu)
+    {
+        switch (menu->logMenuState)
+        {
+            case 10: // map open
+            {
+                if (menu->mapCursorIdx < 0) // no location selected
+                    break;
+                if (menu->buttonsPressed & gc::pad::PadInput::PAD_A && marioGetPtr()->characterId == MarioCharacters::kMario)
+                {
+                    ttyd::evtmgr::evtEntry(const_cast<int32_t *>(confirm_travel_evt), 0, 0);
+                    return -2;
+                }
+                break;
+            }
+            default:
+            {
+                break;
+            }
+        }
+
+        return g_winLogMain_trampoline(menu);
     }
 
     void OWR::Update()

--- a/rel/source/asm/asm_main.s
+++ b/rel/source/asm/asm_main.s
@@ -1,12 +1,16 @@
 .global win_log_mapGX_arr
 .hidden win_log_mapGX_arr
 
+.global bMapGXArrPtrInit
+.global bMapGXArrPtrInitReturn
 .global bMapGXArrInject
 .global bMapGXArrInjectReturn
 .global bMapGXArrIncrement
 .global bMapGXArrIncrementReturn
 .global bMapGXChSplit
 .global bMapGXChSplitReturn
+.global bWinLogArrPtrInit
+.global bWinLogArrPtrInitReturn
 .global bWinLogArrInject
 .global bWinLogArrInjectReturn
 .global bWinLogArrIncrement
@@ -38,9 +42,14 @@
 
 # All of the global symbols in this file excluding win_log_mapGX_arr need to be used in at least one subrel, so they cannot be set to hidden
 
-bMapGXArrInject:
+bMapGXArrPtrInit:
+	addi %r30, %r3, 0x7918 #Original Instruction
 	lis %r3, win_log_mapGX_arr@ha
 	addi %r28, %r3, win_log_mapGX_arr@l
+bMapGXArrPtrInitReturn:
+	b 0
+
+bMapGXArrInject:
 	lhz %r3, 0x0(%r28)
 bMapGXArrInjectReturn:
 	b 0
@@ -58,9 +67,14 @@ bMapGXChSplit:
 bMapGXChSplitReturn:
 	b 0
 
-bWinLogArrInject:
+bWinLogArrPtrInit:
+	fadds %f27, %f0, %f7 #Original Instruction
 	lis %r3, win_log_mapGX_arr@ha
 	addi %r10, %r3, win_log_mapGX_arr@l
+bWinLogArrPtrInitReturn:
+	b 0
+
+bWinLogArrInject:
 	lhz %r3, 0x0(%r10)
 bWinLogArrInjectReturn:
 	b 0
@@ -271,15 +285,15 @@ win_log_mapGX_arr:
 	.2byte 0x06A7
 	.2byte 0x06A7
 	.2byte 0x06A8
-	.2byte 0x06A8
-	.2byte 0x06A8
-	.2byte 0x06A8
-	.2byte 0x06A8
-	.2byte 0x06A8
-	.2byte 0x06A8
-	.2byte 0x06A8
-	.2byte 0x06A8
-	.2byte 0x06A8
+	.2byte 0x06B3
+	.2byte 0x06B3
+	.2byte 0x06B3
+	.2byte 0x06B3
+	.2byte 0x06B3
+	.2byte 0x06B3
+	.2byte 0x06B3
+	.2byte 0x06B3
+	.2byte 0x06B3
 	.2byte 0x06B2
 	.2byte 0x06B2
 	.2byte 0x06B2

--- a/rel/subrels/init/source/OWR.cpp
+++ b/rel/subrels/init/source/OWR.cpp
@@ -549,6 +549,7 @@ namespace mod::owr
         g_statusWinDisp_trampoline = patch::hookFunction(statuswindow::statusWinDisp, DisplayStarPowerNumber);
         g_pouchGetStarstone_trampoline = patch::hookFunction(mario_pouch::pouchGetStarStone, SetMaxSP);
         g_winItemMain_trampoline = patch::hookFunction(win_item::winItemMain, WinItemMainHook);
+        g_winLogMain_trampoline = patch::hookFunction(win_log::main_winLogMain, WinLogMainHook);
 
         // Hook gaugeDisp with a standard branch since the original function does not need to be called
         patch::writeBranch(statuswindow::gaugeDisp, DisplayStarPowerOrbs);

--- a/rel/subrels/init/source/OWR.cpp
+++ b/rel/subrels/init/source/OWR.cpp
@@ -19,6 +19,7 @@
 #include <ttyd/icondrv.h>
 #include <ttyd/item_data.h>
 #include <ttyd/win_item.h>
+#include <ttyd/win_log.h>
 
 #include <cstdint>
 
@@ -154,6 +155,10 @@ namespace mod::owr
         writeIntWithCache(&main_mapGX[238], 0x386006A4); // li r3, 0x6A4 (GSW(1700))
         writeIntWithCache(&main_mapGX[240], 0x2C030010); // cmpwi r3, 0xF
 
+        patch::writeBranchPair(&main_mapGX[90],
+                               reinterpret_cast<void *>(bMapGXArrPtrInit),
+                               reinterpret_cast<void *>(bMapGXArrPtrInitReturn));
+
         patch::writeBranchPair(&main_mapGX[91],
                                reinterpret_cast<void *>(bMapGXArrInject),
                                reinterpret_cast<void *>(bMapGXArrInjectReturn));
@@ -209,6 +214,10 @@ namespace mod::owr
         writeIntWithCache(&main_winLogMain[291], 0x2C030002); // cmpwi r3, 0x2
         writeIntWithCache(&main_winLogMain[295], 0x386006AB); // li r3, 0x6AB (GSW(1707))
         writeIntWithCache(&main_winLogMain[297], 0x2C030001); // cmpwi r3, 0x1
+
+        patch::writeBranchPair(&main_winLogMain[431],
+                               reinterpret_cast<void *>(bWinLogArrPtrInit),
+                               reinterpret_cast<void *>(bWinLogArrPtrInitReturn));
 
         patch::writeBranchPair(&main_winLogMain[432],
                                reinterpret_cast<void *>(bWinLogArrInject),
@@ -491,6 +500,35 @@ namespace mod::owr
         itemDataTable[ItemId::INVALID_ITEM_BOAT_MODE_ICON].description = boatModeNameDescription;
     }
 
+    void ApplyMapMarkerPatches()
+    {
+        using win_log::mapMarkers;
+
+        mapMarkers[0].required_sequence = 0;                                 // gor GSW(1700)
+        for (int i = 1; i <= 3; i++) mapMarkers[i].required_sequence = 11;   // tik GSW(1700)
+        mapMarkers[4].required_sequence = 1;                                 // hei GSW(1701)
+        for (int i = 5; i <= 8; i++) mapMarkers[i].required_sequence = 3;    // nok GSW(1701)
+        for (int i = 9; i <= 12; i++) mapMarkers[i].required_sequence = 2;   // gon GSW(1711)
+        mapMarkers[13].required_sequence = 1;                                // win GSW(1702)
+        for (int i = 14; i <= 15; i++) mapMarkers[i].required_sequence = 3;  // mri GSW(1702)
+        for (int i = 16; i <= 18; i++) mapMarkers[i].required_sequence = 10; // hou GSW(1702) flurries house, so actually win
+        for (int i = 19; i <= 31; i++) mapMarkers[i].required_sequence = 2;  // tou GSW(1703)
+        mapMarkers[32].required_sequence = 2;                                // usu GSW(1704)
+        for (int i = 33; i <= 41; i++) mapMarkers[i].required_sequence = 1;  // gra GSW(1715)
+        // NOTE: sequence is before entering the steeple because we want to use gra_06 (just outside) as a warp point
+        for (int i = 42; i <= 47; i++) mapMarkers[i].required_sequence = 6; // jin GSW(1714)
+        for (int i = 48; i <= 57; i++) mapMarkers[i].required_sequence = 9; // muj GSW(1705)
+        for (int i = 58; i <= 60; i++) mapMarkers[i].required_sequence = 2; // dou GSW(1717)
+        // NOTE: sequence is before entering riverside because we want to use hom_00 (just outside) as a warp point
+        for (int i = 61; i <= 68; i++) mapMarkers[i].required_sequence = 1;  // eki GSW(1720)
+        for (int i = 69; i <= 73; i++) mapMarkers[i].required_sequence = 38; // pik GSW(1706)
+        for (int i = 74; i <= 76; i++) mapMarkers[i].required_sequence = 40; // sin GSW(1706) poshley sanctum so actually pik
+        mapMarkers[77].required_sequence = 2;                                // bom GSW(1707)
+        for (int i = 78; i <= 85; i++) mapMarkers[i].required_sequence = 6;  // moo GSW(1707)
+        for (int i = 86; i <= 89; i++) mapMarkers[i].required_sequence = 9;  // aji GSW(1707)
+        for (int i = 90; i <= 92; i++) mapMarkers[i].required_sequence = 2;  // las GSW(1708)
+    }
+
     OWR::OWR()
     {
         gSelf = this;
@@ -499,6 +537,7 @@ namespace mod::owr
         ApplyMainAssemblyPatches();
         ApplyMainScriptPatches();
         ApplyItemDataTablePatches();
+        ApplyMapMarkerPatches();
 
         g_OSLink_trampoline = patch::hookFunction(OSLink, OSLinkHook);
         gTrampoline_seq_logoMain = patch::hookFunction(seq_logo::seq_logoMain, logoSkip);


### PR DESCRIPTION
Adds an option to enable fast travel from the journal map.

Had to fix the sequence checks for the map markers. I did a test playthrough to verify that the required sequences are correct, but someone more familiar with them should probably double check.

![ttyd_fast_travel](https://github.com/user-attachments/assets/b6c3a779-d0db-4fed-bdf6-e546b7495a3b)
