### PR TITLE
Fix Fahr Outpost map point + change X-Naut Fortress fast travel location

### DIFF
--- a/rel/include/customWarp.h
+++ b/rel/include/customWarp.h
@@ -75,13 +75,13 @@ namespace mod::custom_warp
                 return {"pik_02", "s_bero"};
 
             if (strcmp(map_prefix, "bom") == 0)
-                return {"bom_02", "w_bero"};
+                return {"bom_01", "w_bero"};
 
             if (strcmp(map_prefix, "moo") == 0)
                 return {"moo_00", nullptr}; // first time landing on the moon also uses null
 
             if (strcmp(map_prefix, "aji") == 0)
-                return {"aji_00", "w_bero"};
+                return {"aji_19", "w_bero"};
 
             if (strcmp(map_prefix, "las") == 0)
                 return {"las_00", "w_bero"};

--- a/rel/source/OWR.cpp
+++ b/rel/source/OWR.cpp
@@ -677,7 +677,7 @@ namespace mod::owr
             ttyd::swdrv::swSet(6315);
         else if (strcmp(map, "pik_02") == 0)
             ttyd::swdrv::swSet(6316);
-        else if (strncmp(map, "bom", 3) == 0)
+        else if (strcmp(map, "bom_01") == 0 || strcmp(map, "bom_02") == 0)
             ttyd::swdrv::swSet(6317);
         else if (strncmp(map, "moo", 3) == 0)
             ttyd::swdrv::swSet(6318);


### PR DESCRIPTION
Fahr Outpost fast travel only unlocks in bom_01 (place with cannon) and bom_02 (town), and fast travels you to the place with the cannon, as thats where the title card shows up. This fixes the case where you can skip the first few rooms without making it so you can't easily fast travel to the town.
X-Naut Fortress now fast travels you to aji_19 (the hallway aftering entering the fortress, before the first room with the heart block and save block), as thats where it unlocks. Its literally the room before, but its something I thought I'd change for consistency