### PR TITLE
Disable item tutorial

### DIFF
--- a/rel/source/OWR.cpp
+++ b/rel/source/OWR.cpp
@@ -85,9 +85,10 @@ const uint16_t GSWF_ARR[] = {
     37,
     38,
 
-    // Save block and heart block tutorials
+    // Save block, heart block, and item tutorials
     233,
     234,
+    235,
 
     // Zess T. blocking gate enable
     1187,


### PR DESCRIPTION
I don't need to know what an item is everytime I pick it up, especially if its an AP item and doesn't do anything for me